### PR TITLE
Wrong Field 43 check for Structured Securities vs Funds

### DIFF
--- a/src/main/groovy/convert.groovy
+++ b/src/main/groovy/convert.groovy
@@ -267,7 +267,7 @@ originFileList.each { file ->
                                 !split[41] ?: PortfolioManagement(split[41])
                             }
                             CostsAndChargesExAnte {
-                                if (split[43] != null && split[43] != "") {
+                                if (split[43] == null || split[43] == "") {
                                     // entweder fonds - oder structured security
                                     Fund {
                                         EntryCost(split[43])


### PR DESCRIPTION
According our EMT File Definition (v1.0) Field 43 "07010_Structured_Securities_Quotation" is set mandatory/conditional for Structured Securities. Your expression evaluates to true iff it is set, but then you create a Fund node and not a StructuredSecurity node. Therefore I propose the following change. 

Would you be so kind and let me know if I was correct?

Many thanks and greetings from Vienna!